### PR TITLE
Adding positive and negative sign support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.vscode

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ const parsedCurrency = parseCurrency('$123,456.99USD');
   "symbol": "$",
   "decimalSeparator": ".",
   "groupSeparator": ",",
-  "signal": ""
+  "sign": ""
 }
 
 const parsedCurrency = parseCurrency('-$123,456.99USD');
@@ -53,7 +53,7 @@ const parsedCurrency = parseCurrency('-$123,456.99USD');
   "symbol": "$",
   "decimalSeparator": ".",
   "groupSeparator": ",",
-  "signal": "-"
+  "sign": "-"
 }
 
 const parsedCurrency = parseCurrency('+$123,456.99USD');
@@ -67,7 +67,7 @@ const parsedCurrency = parseCurrency('+$123,456.99USD');
   "symbol": "$",
   "decimalSeparator": ".",
   "groupSeparator": ",",
-  "signal": "+"
+  "sign": "+"
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ const parsedCurrency = parseCurrency('$123,456.99USD');
   "symbol": "$",
   "decimalSeparator": ".",
   "groupSeparator": ",",
-  "signal": ''
+  "signal": ""
 }
 
 const parsedCurrency = parseCurrency('-$123,456.99USD');
@@ -53,7 +53,7 @@ const parsedCurrency = parseCurrency('-$123,456.99USD');
   "symbol": "$",
   "decimalSeparator": ".",
   "groupSeparator": ",",
-  "signal": '-'
+  "signal": "-"
 }
 
 const parsedCurrency = parseCurrency('+$123,456.99USD');
@@ -67,7 +67,7 @@ const parsedCurrency = parseCurrency('+$123,456.99USD');
   "symbol": "$",
   "decimalSeparator": ".",
   "groupSeparator": ",",
-  "signal": '+'
+  "signal": "+"
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Node / browser currency parser.
 
-Extensive currency parsing utility designed to extract value, decimal separator, group separator, currency symbol and iso code from currency string. It should work with most world [currency formats][1] except:
+Extensive currency parsing utility designed to extract value, decimal separator, group separator, currency symbol, iso code and signal from currency string. It should work with most world [currency formats][1] except:
 - currencies with 3 decimals
 - currency with 2 character group separator (Swaziland Lilangeni)
 
@@ -15,6 +15,7 @@ Works with:
 - parsing CHF Swiss Franc (9'000.00 CHF)
 - currency symbols as a prefix / suffix with or without a space
 - currency code before or after the value, with or without space
+- positive and negative signs (before the currency)
 
 ## Install
 
@@ -37,7 +38,36 @@ const parsedCurrency = parseCurrency('$123,456.99USD');
   "currency": "USD",
   "symbol": "$",
   "decimalSeparator": ".",
-  "groupSeparator": ","
+  "groupSeparator": ",",
+  "signal": ''
+}
+
+const parsedCurrency = parseCurrency('-$123,456.99USD');
+// parsedCurrency =>
+{
+  "raw": "-$123,456.99USD",
+  "value": -123456.99,
+  "integer": "-123,456",
+  "decimals": ".99",
+  "currency": "USD",
+  "symbol": "$",
+  "decimalSeparator": ".",
+  "groupSeparator": ",",
+  "signal": '-'
+}
+
+const parsedCurrency = parseCurrency('+$123,456.99USD');
+// parsedCurrency =>
+{
+  "raw": "+$123,456.99USD",
+  "value": 123456.99,
+  "integer": "123,456",
+  "decimals": ".99",
+  "currency": "USD",
+  "symbol": "$",
+  "decimalSeparator": ".",
+  "groupSeparator": ",",
+  "signal": '+'
 }
 
 ```

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var currencyMatcher = /^(?:([-,+]{1}) ?)?(?:(\p{Sc}{1,5}) ?)?(?:([A-Z]{3}) ?)?(?:([^\d ]+?) ?)?(((?:\d{1,3}([,. ’'\u00A0]))*?\d{1,})(([,.])\d{1,2})?)(?: ?([^\d ]+?))??(?: ?([A-Z]{3}))?$/;
+var currencyMatcher = /^(?:([-+]{1}) ?)?(?:([A-Z]{3}) ?)?(?:([^\d ]+?) ?)?(((?:\d{1,3}([,. ’'\u00A0]))*?\d{1,})(([,.])\d{1,2})?)(?: ?([^\d ]+?))??(?: ?([A-Z]{3}))?$/;
 var gr = /^\d{1,3}([,. ’'\u00A0]\d{3})*$/; // validate groups
 var ind = /^\d{1,2}(,\d{2})*(,\d{3})?$/; // exception for Indian number format
 
@@ -7,16 +7,16 @@ module.exports = function parseCurrency(priceStr) {
   priceStr = priceStr.trim();
   var match = priceStr.match(currencyMatcher);
   if (!match) return null;
-  var groupSeparator = match[7] || '';
-  var decimalSeparator = match[9] || '';
+  var groupSeparator = match[6] || '';
+  var decimalSeparator = match[8] || '';
   if (groupSeparator === decimalSeparator && decimalSeparator) {
     return null;
   }
-  var integer = match[1] == '-' ? '-' + match[6] : match[6];
-  if (groupSeparator && !match[6].match(gr) && !match[6].match(ind)) {
+  var integer = match[1] == '-' ? '-' + match[5] : match[5];
+  if (groupSeparator && !match[5].match(gr) && !match[5].match(ind)) {
     return null;
   }
-  var value = match[5];
+  var value = match[4];
   if (!value) return null;
   if (groupSeparator) {
     value = value.replace(RegExp('\\' + groupSeparator, 'g'), '');
@@ -32,9 +32,9 @@ module.exports = function parseCurrency(priceStr) {
     raw: priceStr,
     value: numericVal,
     integer: integer || '',
-    decimals: match[8] || '',
-    currency: match[3] || match[11] || '',
-    symbol: match[4] || match[10] || '',
+    decimals: match[7] || '',
+    currency: match[2] || match[10] || '',
+    symbol: match[3] || match[9] || '',
     decimalSeparator: decimalSeparator,
     groupSeparator: groupSeparator,
     sign: match[1] || ''

--- a/index.js
+++ b/index.js
@@ -1,22 +1,22 @@
-var currencyMatcher = /^(?:([A-Z]{3}) ?)?(?:([^\d ]+?) ?)?(((?:\d{1,3}([,. ’'\u00A0]))*?\d{1,})(([,.])\d{1,2})?)(?: ?([^\d ]+?))??(?: ?([A-Z]{3}))?$/;
+var currencyMatcher = /^(?:([-,+]{1}) ?)?(?:(\p{Sc}{1,5}) ?)?(?:([A-Z]{3}) ?)?(?:([^\d ]+?) ?)?(((?:\d{1,3}([,. ’'\u00A0]))*?\d{1,})(([,.])\d{1,2})?)(?: ?([^\d ]+?))??(?: ?([A-Z]{3}))?$/;
 var gr = /^\d{1,3}([,. ’'\u00A0]\d{3})*$/; // validate groups
 var ind = /^\d{1,2}(,\d{2})*(,\d{3})?$/; // exception for Indian number format
 
-module.exports = function parseCurrency (priceStr) {
+module.exports = function parseCurrency(priceStr) {
   if (!priceStr || !priceStr.match) return null;
   priceStr = priceStr.trim();
   var match = priceStr.match(currencyMatcher);
   if (!match) return null;
-  var groupSeparator = match[5] || '';
-  var decimalSeparator = match[7] || '';
+  var groupSeparator = match[7] || '';
+  var decimalSeparator = match[9] || '';
   if (groupSeparator === decimalSeparator && decimalSeparator) {
     return null;
   }
-  var integer = match[4];
-  if (groupSeparator && !integer.match(gr) && !integer.match(ind)) {
+  var integer = match[1] == '-' ? '-' + match[6] : match[6];
+  if (groupSeparator && !match[6].match(gr) && !match[6].match(ind)) {
     return null;
   }
-  var value = match[3];
+  var value = match[5];
   if (!value) return null;
   if (groupSeparator) {
     value = value.replace(RegExp('\\' + groupSeparator, 'g'), '');
@@ -24,7 +24,7 @@ module.exports = function parseCurrency (priceStr) {
   if (decimalSeparator) {
     value = value.replace(decimalSeparator, '.');
   }
-  var numericVal = +value;
+  var numericVal = match[1] == '-' ? value * -1 : +value;
   if (typeof numericVal !== 'number' || isNaN(numericVal)) {
     return null;
   }
@@ -32,10 +32,11 @@ module.exports = function parseCurrency (priceStr) {
     raw: priceStr,
     value: numericVal,
     integer: integer || '',
-    decimals: match[6] || '',
-    currency: match[1] || match[9] || '',
-    symbol: match[2] || match[8] || '',
+    decimals: match[8] || '',
+    currency: match[3] || match[11] || '',
+    symbol: match[4] || match[10] || '',
     decimalSeparator: decimalSeparator,
-    groupSeparator: groupSeparator
+    groupSeparator: groupSeparator,
+    sign: match[1] || ''
   };
 };

--- a/test.js
+++ b/test.js
@@ -12,7 +12,8 @@ describe('utils/parseCurrency', () => {
       currency: '',
       symbol: '',
       decimalSeparator: '',
-      groupSeparator: ''
+      groupSeparator: '',
+      sign: ''
     });
   });
 
@@ -25,7 +26,8 @@ describe('utils/parseCurrency', () => {
       currency: '',
       symbol: '$',
       decimalSeparator: '',
-      groupSeparator: ''
+      groupSeparator: '',
+      sign: ''
     });
 
     expect(parseCurrency('100$')).to.deep.equal({
@@ -36,7 +38,8 @@ describe('utils/parseCurrency', () => {
       currency: '',
       symbol: '$',
       decimalSeparator: '',
-      groupSeparator: ''
+      groupSeparator: '',
+      sign: ''
     });
   });
 
@@ -49,7 +52,8 @@ describe('utils/parseCurrency', () => {
       currency: 'EUR',
       symbol: '',
       decimalSeparator: '.',
-      groupSeparator: ','
+      groupSeparator: ',',
+      sign: ''
     });
 
     expect(parseCurrency('100 USD')).to.deep.equal({
@@ -60,7 +64,8 @@ describe('utils/parseCurrency', () => {
       currency: 'USD',
       symbol: '',
       decimalSeparator: '',
-      groupSeparator: ''
+      groupSeparator: '',
+      sign: ''
     });
 
     expect(parseCurrency('USD 100')).to.deep.equal({
@@ -71,7 +76,8 @@ describe('utils/parseCurrency', () => {
       currency: 'USD',
       symbol: '',
       decimalSeparator: '',
-      groupSeparator: ''
+      groupSeparator: '',
+      sign: ''
     });
 
     expect(parseCurrency('$100 USD')).to.deep.equal({
@@ -82,7 +88,8 @@ describe('utils/parseCurrency', () => {
       currency: 'USD',
       symbol: '$',
       decimalSeparator: '',
-      groupSeparator: ''
+      groupSeparator: '',
+      sign: ''
     });
 
     expect(parseCurrency('USD $100')).to.deep.equal({
@@ -93,7 +100,8 @@ describe('utils/parseCurrency', () => {
       currency: 'USD',
       symbol: '$',
       decimalSeparator: '',
-      groupSeparator: ''
+      groupSeparator: '',
+      sign: ''
     });
   });
 
@@ -106,7 +114,8 @@ describe('utils/parseCurrency', () => {
       currency: '',
       symbol: '',
       decimalSeparator: '',
-      groupSeparator: ''
+      groupSeparator: '',
+      sign: ''
     });
 
     expect(parseCurrency('100,000,000')).to.deep.equal({
@@ -117,7 +126,8 @@ describe('utils/parseCurrency', () => {
       currency: '',
       symbol: '',
       decimalSeparator: '',
-      groupSeparator: ','
+      groupSeparator: ',',
+      sign: ''
     });
 
     expect(parseCurrency('€10,000.00 EUR')).to.deep.equal({
@@ -128,7 +138,8 @@ describe('utils/parseCurrency', () => {
       currency: 'EUR',
       symbol: '€',
       decimalSeparator: '.',
-      groupSeparator: ','
+      groupSeparator: ',',
+      sign: ''
     });
   });
 
@@ -141,7 +152,8 @@ describe('utils/parseCurrency', () => {
       currency: 'USD',
       symbol: '$',
       decimalSeparator: '.',
-      groupSeparator: ''
+      groupSeparator: '',
+      sign: ''
     });
 
     expect(parseCurrency('€10.000,00 EUR')).to.deep.equal({
@@ -152,7 +164,8 @@ describe('utils/parseCurrency', () => {
       currency: 'EUR',
       symbol: '€',
       decimalSeparator: ',',
-      groupSeparator: '.'
+      groupSeparator: '.',
+      sign: ''
     });
 
     expect(parseCurrency('PLN 10 000,00zł')).to.deep.equal({
@@ -163,7 +176,8 @@ describe('utils/parseCurrency', () => {
       currency: 'PLN',
       symbol: 'zł',
       decimalSeparator: ',',
-      groupSeparator: ' '
+      groupSeparator: ' ',
+      sign: ''
     });
   });
 
@@ -176,7 +190,8 @@ describe('utils/parseCurrency', () => {
       currency: '',
       symbol: ' zł',
       decimalSeparator: ',',
-      groupSeparator: ' '
+      groupSeparator: ' ',
+      sign: ''
     });
   });
 
@@ -189,7 +204,8 @@ describe('utils/parseCurrency', () => {
       currency: '',
       symbol: '',
       decimalSeparator: ',',
-      groupSeparator: ''
+      groupSeparator: '',
+      sign: ''
     });
 
     expect(parseCurrency('100,000')).to.deep.equal({
@@ -200,7 +216,8 @@ describe('utils/parseCurrency', () => {
       currency: '',
       symbol: '',
       decimalSeparator: '',
-      groupSeparator: ','
+      groupSeparator: ',',
+      sign: ''
     });
   });
 
@@ -213,7 +230,8 @@ describe('utils/parseCurrency', () => {
       currency: '',
       symbol: '¥',
       decimalSeparator: '',
-      groupSeparator: ','
+      groupSeparator: ',',
+      sign: ''
     });
 
     expect(parseCurrency('Fr. 578’349’026.76')).to.deep.equal({
@@ -224,7 +242,8 @@ describe('utils/parseCurrency', () => {
       currency: '',
       symbol: 'Fr.',
       decimalSeparator: '.',
-      groupSeparator: '’'
+      groupSeparator: '’',
+      sign: ''
     });
 
     expect(parseCurrency('10\'000 CHF')).to.deep.equal({
@@ -235,7 +254,8 @@ describe('utils/parseCurrency', () => {
       currency: 'CHF',
       symbol: '',
       decimalSeparator: '',
-      groupSeparator: '\''
+      groupSeparator: '\'',
+      sign: ''
     });
   });
 
@@ -248,7 +268,8 @@ describe('utils/parseCurrency', () => {
       integer: '1,50,000',
       raw: '₹1,50,000.00',
       symbol: '₹',
-      value: 150000
+      value: 150000,
+      sign: ''
     });
   });
 
@@ -261,7 +282,8 @@ describe('utils/parseCurrency', () => {
       currency: '',
       symbol: '',
       decimalSeparator: ',',
-      groupSeparator: ''
+      groupSeparator: '',
+      sign: ''
     });
   });
 
@@ -288,5 +310,421 @@ describe('utils/parseCurrency', () => {
     expect(parseCurrency('100..00')).to.equal(null);
     expect(parseCurrency('1,000.000')).to.equal(null);
     expect(parseCurrency('1,000.000,00')).to.equal(null);
+  });
+
+  it('should work with leading positive sign (+)', () => {
+    expect(parseCurrency('+100,00')).to.deep.equal({
+      raw: '+100,00',
+      value: 100,
+      integer: '100',
+      decimals: ',00',
+      currency: '',
+      symbol: '',
+      decimalSeparator: ',',
+      groupSeparator: '',
+      sign: '+'
+    });
+  });
+
+  it('should work with leading positive sign (+) + symbol', () => {
+    expect(parseCurrency('+R$100,00')).to.deep.equal({
+      raw: '+R$100,00',
+      value: 100,
+      integer: '100',
+      decimals: ',00',
+      currency: '',
+      symbol: 'R$',
+      decimalSeparator: ',',
+      groupSeparator: '',
+      sign: '+'
+    });
+  });
+
+  it('should work with leading positive sign (+) + symbol(US$)', () => {
+    expect(parseCurrency('+US$100,00')).to.deep.equal({
+      raw: '+US$100,00',
+      value: 100,
+      integer: '100',
+      decimals: ',00',
+      currency: '',
+      symbol: 'US$',
+      decimalSeparator: ',',
+      groupSeparator: '',
+      sign: '+'
+    });
+  });
+
+  it('should work with leading positive sign (+) + space', () => {
+    expect(parseCurrency('+ 100,00')).to.deep.equal({
+      raw: '+ 100,00',
+      value: 100,
+      integer: '100',
+      decimals: ',00',
+      currency: '',
+      symbol: '',
+      decimalSeparator: ',',
+      groupSeparator: '',
+      sign: '+'
+    });
+  });
+
+  it('should work with leading space + positive sign (+)', () => {
+    expect(parseCurrency(' +100,00')).to.deep.equal({
+      raw: '+100,00',
+      value: 100,
+      integer: '100',
+      decimals: ',00',
+      currency: '',
+      symbol: '',
+      decimalSeparator: ',',
+      groupSeparator: '',
+      sign: '+'
+    });
+  });
+
+  it('should work with leading space + positive sign (+) + space', () => {
+    expect(parseCurrency(' + 100,00')).to.deep.equal({
+      raw: '+ 100,00',
+      value: 100,
+      integer: '100',
+      decimals: ',00',
+      currency: '',
+      symbol: '',
+      decimalSeparator: ',',
+      groupSeparator: '',
+      sign: '+'
+    });
+  });
+
+  it('should work with leading negative sign (-)', () => {
+    expect(parseCurrency('-100,00')).to.deep.equal({
+      raw: '-100,00',
+      value: -100,
+      integer: '-100',
+      decimals: ',00',
+      currency: '',
+      symbol: '',
+      decimalSeparator: ',',
+      groupSeparator: '',
+      sign: '-'
+    });
+  });
+
+  it('should work with leading negative sign (-) + symbol', () => {
+    expect(parseCurrency('-R$100,00')).to.deep.equal({
+      raw: '-R$100,00',
+      value: -100,
+      integer: '-100',
+      decimals: ',00',
+      currency: '',
+      symbol: 'R$',
+      decimalSeparator: ',',
+      groupSeparator: '',
+      sign: '-'
+    });
+  });
+
+  it('should work with leading negative sign (-) + symbol(US$)', () => {
+    expect(parseCurrency('-US$100,00')).to.deep.equal({
+      raw: '-US$100,00',
+      value: -100,
+      integer: '-100',
+      decimals: ',00',
+      currency: '',
+      symbol: 'US$',
+      decimalSeparator: ',',
+      groupSeparator: '',
+      sign: '-'
+    });
+  });
+
+  it('should work with leading negative sign (-) + space', () => {
+    expect(parseCurrency('- 100,00')).to.deep.equal({
+      raw: '- 100,00',
+      value: -100,
+      integer: '-100',
+      decimals: ',00',
+      currency: '',
+      symbol: '',
+      decimalSeparator: ',',
+      groupSeparator: '',
+      sign: '-'
+    });
+  });
+
+  it('should work with leading space + negative sign (+) + space', () => {
+    expect(parseCurrency(' - 100,00')).to.deep.equal({
+      raw: '- 100,00',
+      value: -100,
+      integer: '-100',
+      decimals: ',00',
+      currency: '',
+      symbol: '',
+      decimalSeparator: ',',
+      groupSeparator: '',
+      sign: '-'
+    });
+  });
+
+
+  it('should work with real world positive (¥) example', () => {
+    expect(parseCurrency('+¥578,349,027')).to.deep.equal({
+      raw: '+¥578,349,027',
+      value: 578349027,
+      integer: '578,349,027',
+      decimals: '',
+      currency: '',
+      symbol: '¥',
+      decimalSeparator: '',
+      groupSeparator: ',',
+      sign: '+'
+    });
+  });
+
+  it('should work with real world negative (¥) example', () => {
+    expect(parseCurrency('-¥578,349,027')).to.deep.equal({
+      raw: '-¥578,349,027',
+      value: -578349027,
+      integer: '-578,349,027',
+      decimals: '',
+      currency: '',
+      symbol: '¥',
+      decimalSeparator: '',
+      groupSeparator: ',',
+      sign: '-'
+    });
+  });
+
+  it('should work with real world negative (Fr.) example', () => {
+    expect(parseCurrency('-Fr. 578’349’026.76')).to.deep.equal({
+      raw: '-Fr. 578’349’026.76',
+      value: -578349026.76,
+      integer: '-578’349’026',
+      decimals: '.76',
+      currency: '',
+      symbol: 'Fr.',
+      decimalSeparator: '.',
+      groupSeparator: '’',
+      sign: '-'
+    });
+  });
+
+  it('should work with real world positive (Fr.) example', () => {
+    expect(parseCurrency('+Fr. 578’349’026.76')).to.deep.equal({
+      raw: '+Fr. 578’349’026.76',
+      value: 578349026.76,
+      integer: '578’349’026',
+      decimals: '.76',
+      currency: '',
+      symbol: 'Fr.',
+      decimalSeparator: '.',
+      groupSeparator: '’',
+      sign: '+'
+    });
+  });
+
+  it('should work with real world negative (CHF) example', () => {
+    expect(parseCurrency('-10\'000 CHF')).to.deep.equal({
+      raw: '-10\'000 CHF',
+      value: -10000,
+      integer: '-10\'000',
+      decimals: '',
+      currency: 'CHF',
+      symbol: '',
+      decimalSeparator: '',
+      groupSeparator: '\'',
+      sign: '-'
+    });
+  });
+
+  it('should work with real world positive (CHF) example', () => {
+    expect(parseCurrency('+10\'000 CHF')).to.deep.equal({
+      raw: '+10\'000 CHF',
+      value: 10000,
+      integer: '10\'000',
+      decimals: '',
+      currency: 'CHF',
+      symbol: '',
+      decimalSeparator: '',
+      groupSeparator: '\'',
+      sign: '+'
+    });
+  });
+
+  it('should parse strings with currency symbol (negative)', () => {
+    expect(parseCurrency('-$100')).to.deep.equal({
+      raw: '-$100',
+      value: -100,
+      integer: '-100',
+      decimals: '',
+      currency: '',
+      symbol: '$',
+      decimalSeparator: '',
+      groupSeparator: '',
+      sign: '-'
+    });
+
+    expect(parseCurrency('-100$')).to.deep.equal({
+      raw: '-100$',
+      value: -100,
+      integer: '-100',
+      decimals: '',
+      currency: '',
+      symbol: '$',
+      decimalSeparator: '',
+      groupSeparator: '',
+      sign: '-'
+    });
+  });
+
+  it('should parse strings with currency ISO code (negative)', () => {
+    expect(parseCurrency('-160,000.00 EUR')).to.deep.equal({
+      raw: '-160,000.00 EUR',
+      value: -160000.00,
+      integer: '-160,000',
+      decimals: '.00',
+      currency: 'EUR',
+      symbol: '',
+      decimalSeparator: '.',
+      groupSeparator: ',',
+      sign: '-'
+    });
+
+    expect(parseCurrency('-100 USD')).to.deep.equal({
+      raw: '-100 USD',
+      value: -100,
+      integer: '-100',
+      decimals: '',
+      currency: 'USD',
+      symbol: '',
+      decimalSeparator: '',
+      groupSeparator: '',
+      sign: '-'
+    });
+
+    expect(parseCurrency('-USD 100')).to.deep.equal({
+      raw: '-USD 100',
+      value: -100,
+      integer: '-100',
+      decimals: '',
+      currency: 'USD',
+      symbol: '',
+      decimalSeparator: '',
+      groupSeparator: '',
+      sign: '-'
+    });
+
+    expect(parseCurrency('-$100 USD')).to.deep.equal({
+      raw: '-$100 USD',
+      value: -100,
+      integer: '-100',
+      decimals: '',
+      currency: 'USD',
+      symbol: '$',
+      decimalSeparator: '',
+      groupSeparator: '',
+      sign: '-'
+    });
+
+    expect(parseCurrency('-USD $100')).to.deep.equal({
+      raw: '-USD $100',
+      value: -100,
+      integer: '-100',
+      decimals: '',
+      currency: 'USD',
+      symbol: '$',
+      decimalSeparator: '',
+      groupSeparator: '',
+      sign: '-'
+    });
+  });
+
+  
+  it('should parse strings with currency symbol (positive)', () => {
+    expect(parseCurrency('+$100')).to.deep.equal({
+      raw: '+$100',
+      value: 100,
+      integer: '100',
+      decimals: '',
+      currency: '',
+      symbol: '$',
+      decimalSeparator: '',
+      groupSeparator: '',
+      sign: '+'
+    });
+
+    expect(parseCurrency('+100$')).to.deep.equal({
+      raw: '+100$',
+      value: 100,
+      integer: '100',
+      decimals: '',
+      currency: '',
+      symbol: '$',
+      decimalSeparator: '',
+      groupSeparator: '',
+      sign: '+'
+    });
+  });
+
+  it('should parse strings with currency ISO code (positive)', () => {
+    expect(parseCurrency('+160,000.00 EUR')).to.deep.equal({
+      raw: '+160,000.00 EUR',
+      value: 160000.00,
+      integer: '160,000',
+      decimals: '.00',
+      currency: 'EUR',
+      symbol: '',
+      decimalSeparator: '.',
+      groupSeparator: ',',
+      sign: '+'
+    });
+
+    expect(parseCurrency('+100 USD')).to.deep.equal({
+      raw: '+100 USD',
+      value: 100,
+      integer: '100',
+      decimals: '',
+      currency: 'USD',
+      symbol: '',
+      decimalSeparator: '',
+      groupSeparator: '',
+      sign: '+'
+    });
+
+    expect(parseCurrency('+USD 100')).to.deep.equal({
+      raw: '+USD 100',
+      value: 100,
+      integer: '100',
+      decimals: '',
+      currency: 'USD',
+      symbol: '',
+      decimalSeparator: '',
+      groupSeparator: '',
+      sign: '+'
+    });
+
+    expect(parseCurrency('+$100 USD')).to.deep.equal({
+      raw: '+$100 USD',
+      value: 100,
+      integer: '100',
+      decimals: '',
+      currency: 'USD',
+      symbol: '$',
+      decimalSeparator: '',
+      groupSeparator: '',
+      sign: '+'
+    });
+
+    expect(parseCurrency('+USD $100')).to.deep.equal({
+      raw: '+USD $100',
+      value: 100,
+      integer: '100',
+      decimals: '',
+      currency: 'USD',
+      symbol: '$',
+      decimalSeparator: '',
+      groupSeparator: '',
+      sign: '+'
+    });
   });
 });


### PR DESCRIPTION
Hello,

Sending a pull request proposal to update the support on negative and positive signs. I've added test cases to the ones that already existed, in order to comply with earlier version support.

Related to issue https://github.com/mktj/parsecurrency/issues/10 .

Please let me know if I can be of any further help.

Thank you.